### PR TITLE
Fix filtering activities

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -4,12 +4,17 @@
  * Reaches into the activity global and filters out items the user doesn't have access to
  *
  * Uses privacy settings from More Privacy Options
+ *
+ * @param boolean $has_activities True if there are activities, false otherwise
+ * @param object $activities The BP activities template object
+ * @param array $template_args The arguments used to init $activities_template
+ * @return boolean $has_activities True if there are activities, false otherwise
  */
-function bp_mpo_activity_filter( $a, $activities ) {
+function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) {
 	global $bp;
 
 	if ( is_super_admin() )
-		return $activities;
+		return $has_activities;
 
 	foreach ( $activities->activities as $key => $activity ) {
 		if ( $activity->type == 'new_blog_post' || $activity->type == 'new_blog_comment' ) {
@@ -96,9 +101,9 @@ function bp_mpo_activity_filter( $a, $activities ) {
 	$activities_new = array_values( $activities->activities );
 	$activities->activities = $activities_new;
 
-	return $activities;
+	return $activities->has_activities();
 }
-add_action( 'bp_has_activities', 'bp_mpo_activity_filter', 10, 2 );
+add_filter( 'bp_has_activities', 'bp_mpo_activity_filter', 10, 3 );
 
 
 // Filter the output of 'bp_get_activity_count' to account for the fact that there are fewer items. A total hack.

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Plugin Name ===
+=== BP MPO Activity Filter ===
 Contributors: boonebgorges, cuny-academic-commons
 Tags: buddypress, activity, privacy, more privacy options, filter
 Requires at least: WP 2.8, BuddyPress 1.2


### PR DESCRIPTION
Not sure this is the right thing to be doing in terms of backwards compat - given that this plugin seems to support BP back to its origins - but, in more recent versions of BP, the activities filter is returning the whole activity template object instead of the boolean `has_activities`.

Obviously, no rush @boonebgorges hope all's well :grin: 