### PR TITLE
add new_blog activity type to filter

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -17,7 +17,7 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 		return $has_activities;
 
 	foreach ( $activities->activities as $key => $activity ) {
-		if ( $activity->type == 'new_blog_post' || $activity->type == 'new_blog_comment' ) {
+		if ( $activity->type == 'new_blog' || $activity->type == 'new_blog_post' || $activity->type == 'new_blog_comment' ) {
 
 			$current_user = $bp->loggedin_user->id;
 


### PR DESCRIPTION
Hi Boone.

We noticed activities being posted for new site creation when the site is set to be only visible to administrators, which resulted in "broken" links for any user who isn't the site admin. This patch prevents that from happening.