### PR TITLE
Fix "continue" targeting switch is equivalent to "break" warnings

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -48,12 +48,12 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 
 			switch ( $privacy ) {
 				case '1':
-					continue;
+					continue 2;
 					break;
 
 				case '0':
 					if ( $current_user != 0 ) {
-						continue;
+						continue 2;
 						}
 					else {
 						$remove_from_stream = true;
@@ -63,7 +63,7 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 
 				case '-1':
 					if ( $current_user != 0 )
-						continue;
+						continue 2;
 					else {
 						$remove_from_stream = true;
 					}
@@ -75,7 +75,7 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 						$caps = get_user_meta( $current_user, $meta_key, true );
 
 						if ( !empty( $caps ) ) {
-							continue;
+							continue 2;
 						} else {
 							$remove_from_stream = true;
 						}
@@ -91,7 +91,7 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 						$user = new WP_User( $current_user );
 
 						if ( in_array( 'administrator', $user->roles ) )
-							continue;
+							continue 2;
 						else {
 							$remove_from_stream = true;
 						}


### PR DESCRIPTION
Hi Boone,

Was seeing the followings warnings in my debug log and thought I'd fix them up :)

```
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?
```