### PR TITLE
Use restore_current_blog() before bailing during admins-only check

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -90,9 +90,10 @@ function bp_mpo_activity_filter( $has_activities, $activities, $template_args ) 
 
 						$user = new WP_User( $current_user );
 
-						if ( in_array( 'administrator', $user->roles ) )
+						if ( in_array( 'administrator', $user->roles ) ) {
+							restore_current_blog();
 							continue 2;
-						else {
+						} else {
 							$remove_from_stream = true;
 						}
 						restore_current_blog();


### PR DESCRIPTION
Hi Boone,

We need to reset the current blog before bailing out of the admins-only privacy check to ensure no lingering effects.

You actually fixed this on the Commons, but forgot to backport it here :)