### PR TITLE
Prevent activity from private sites to be visible in sitewide stream

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -125,3 +125,21 @@ function bp_mpo_activity_count() {
 	return '20';
 }
 add_action( 'bp_get_activity_count', 'bp_mpo_activity_count' );
+
+/**
+ * Prevent activity from private sites to be visible in sitewide stream.
+ *
+ * We deem a site as private, if the Site Visibility setting is anything
+ * but "Allow search engines to index this site". If a site is private,
+ * we set the 'hide_sitewide' activity flag to 1.
+ *
+ * @param BP_Activity_Activity $activity Activity object.
+ */
+function bp_mpo_set_hide_sitewide_for_private_sites( $activity ) {
+	$privacy = (int) get_option( 'blog_public' );
+
+	if ( $privacy < 1 ) {
+		$activity->hide_sitewide = 1;
+	}
+}
+add_action( 'bp_activity_before_save', 'bp_mpo_set_hide_sitewide_for_private_sites', 0 );


### PR DESCRIPTION
BuddyPress will record blog post and comments into the activity stream if the Site Visibility setting is not zero:
https://github.com/buddypress/buddypress/blob/fea0e21ecc2847933bebc3b0aa126c519cda1082/src/bp-blogs/bp-blogs-filters.php#L107-L118

Because the More Privacy Options plugin adds visibility options that have negative values, this means that blog post and comment activity from private sites will end up being recorded and visible in the sitewide activity stream.

This PR opts to set the `'hide_sitewide'` activity flag to zero for blog posts and comments from private sites.

However, it's worthwhile to note that if the Site Visibility option is set to `0` (Discourage search engines from indexing this site), BuddyPress will not even record the activity item. Instead of hiding the activity item as in this PR, should we be actively blocking the activity item from being recorded in the first place?

Having a record in the activity stream might be beneficial, so I opted to just hide it. ~But we can switch to blocking if we want to mirror what BuddyPress is doing.~ Looks like we decided internally to not do what BuddyPress is doing, so this PR should be fine.