### PR TITLE
Ensure 'new_blog' activity item for private sites is hidden sitewide

### DIFF
--- a/bp-mpo-activity-filter-bp-functions.php
+++ b/bp-mpo-activity-filter-bp-functions.php
@@ -136,7 +136,11 @@ add_action( 'bp_get_activity_count', 'bp_mpo_activity_count' );
  * @param BP_Activity_Activity $activity Activity object.
  */
 function bp_mpo_set_hide_sitewide_for_private_sites( $activity ) {
-	$privacy = (int) get_option( 'blog_public' );
+	if ( 'blogs' !== $activity->component ) {
+		return;
+	}
+
+	$privacy = (int) get_blog_option( $activity->item_id, 'blog_public' );
 
 	if ( $privacy < 1 ) {
 		$activity->hide_sitewide = 1;


### PR DESCRIPTION
Addendum to #11.

Previous commit (8e6a0ff) referenced the current site's visibility setting. However, when a new site is created, it is created from the main site, which is usually public.

This meant the `'new_blog'` activity item could use the wrong `'hide_sitewide'` value if the newly-created site is private. Oops!